### PR TITLE
platform-dependent packaging support using Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2017-07-23
+### Added
+- Support for compiling platform-dependent packages using Docker. Even Santa isn't this nice.
+
+### Changed
+- Included Docker integration instructions in README.md. If you build it and tell them how to use it, they will come.
+
+
+### Removed

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ import common1, common2, requests, simplejson
 ```
 in function1/lambda.py works like works like a charm!
 
+The plugin also supports packaging your dependencies using a Docker Image that replicates your cloud providers environment, allowing you easily work with platform-dependent libraries like numpy.
+
 
 ## <a id="how">How does it work?</a>
 The plugin handles the creation of the [artifact zip files](https://serverless.com/framework/docs/providers/aws/guide/packaging#artifact) for your Serverless functions.
@@ -117,11 +119,15 @@ functions:
 ```
 
 The plugin configurations are simple:
-- `buildDir`: (Required) Path to a build directory the plugin can work in. It is created by the plugin if it doesn't exist.
-- `requirementsFile`: (Optional, Defaults to `requirements.txt`) The name of the pip requirements file for each function. All function-level requirements files must use the name specified here
-- `globalRequirements`: (Optional) A list of paths to files containing service-level pip requirements
-- `globalIncludes`: (Optional) A list of paths to folders containing service-level code files (i.e. code common to all functions)
-- `cleanup`: (Optional, Defaults to true) Boolean indicating whether or not to delete the build directory after Serverless is done uploading the artifacts
+| Configuration      | Description                                                                                                                                                                                                        | Optional?                                                  |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|
+| buildDir           | Path to a build directory relative to project root, e.g. build                                                                                                                                                     | No                                                         |
+| requirementsFile   | The name of the requirements file used for function-level requirements. All function-level requirements files must use the name specified here.                                                                    | Yes. Defaults to `requirements.txt`                        |
+| globalRequirements | A list of paths to files containing service-level pip requirements.                                                                                                                                                | Yes                                                        |
+| globalIncludes     | A list of paths to folders containing service-level code files (i.e. code common to all functions). Only the folders contents will be packaged, not the folder itself. Paths to files are not currently supported. | Yes                                                        |
+| useDocker          | Boolean indicating whether to package pip dependencies using Docker. Set this to true if your project uses platform-specific compiled libraries like numpy. Requires a Docker installation.                        | Yes. Defaults to `false`                                   |
+| dockerImage        | The Docker image to use to compile functions if `useDocker` is set to `true`. If the image doesn't exist on the system, it will be downloaded. The initial download may take some time.                            | Yes. Defaults to `lambci/lambda:build-${provider.runtime}` |
+| containerName      | The desired name for the Docker container.                                                                                                                                                                         | Yes. Defaults to `serverless-package-python-functions`     |
 
 At the function level, you:
 - Specify `name` to give your function a name. The plugin uses the function's name as the name of the zip artifact


### PR DESCRIPTION
# What did you implement?
Closes #4
A feature that allows users python packages to be compiled in a Docker AWS Lambda Container.

# How Does the Feature Work
User specifies the `useDocker: true` option in the configuration as such:
```
service: your-awesome-project

plugins:
  - serverless-package-python-functions

custom:
  pkgPyFuncs:
    buildDir: _build
    requirementsFile: 'requirements.txt'
    globalRequirements:
      - ./requirements.txt
    globalIncludes:
      - ./common_files
    cleanup: true
    useDocker: true
```

When the plugin runs, it compiles the python pip packages inside a Docker AWS Lambda container, so that they are guaranteed to work when deployed.
Users can also use the `dockerImage` configuration to specify the Docker Image they want to use, and the `containerName` configuration to specify what they want the container to be named. Documentation was updated to reflect the changes.