### PR TITLE
updating readme to use stage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ When `serverless deploy` is run, the plugin will:
 The Serverless framework will then pickup each zip file and upload it to your provider.
 
 Here's a simple `serverless.yml` configuration for this plugin, assuming the project structure above
+one of the fuctions we add `-${opt:stage}` to the name in order to the stage to the function name
 
 ```
 service: your-awesome-project
@@ -110,7 +111,7 @@ functions:
       artifact: ${self:custom.pkgPyFuncs.buildDir}/function1.zip
 
   function2:
-    name: function2-${opt:stage}
+    name: function2
     handler: lambda.handler
     package:
       include:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ custom:
 
 functions:
   function1:
-    name: function1
+    name: function1-${opt:stage}
     handler: lambda.handler
     package:
       include:
@@ -110,7 +110,7 @@ functions:
       artifact: ${self:custom.pkgPyFuncs.buildDir}/function1.zip
 
   function2:
-    name: function2
+    name: function2-${opt:stage}
     handler: lambda.handler
     package:
       include:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ When `serverless deploy` is run, the plugin will:
 The Serverless framework will then pickup each zip file and upload it to your provider.
 
 Here's a simple `serverless.yml` configuration for this plugin, assuming the project structure above
-one of the fuctions we add `-${opt:stage}` to the name in order to the stage to the function name
+one of the fuctions we add `-${opt:stage}` to the name in order to append the stage to the function name
 
 ```
 service: your-awesome-project


### PR DESCRIPTION
Instead of building in stage into the naming, simply call for it in serverless.yml. Would be nice to have this as part of the example docs. I'm assuming others deploy to dev/stage/prod 