### PR TITLE
Use the specified function artifact name while packaging

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ class PkgPyFuncs {
     const info = _.map(functions, (target) => {
       return {
         name: target.name,
-        includes: target.package.include
+        includes: target.package.include,
+	artifact: target.package.artifact
       }
     })
     return info
@@ -139,7 +140,7 @@ class PkgPyFuncs {
   }
 
   makePackage(target){
-    this.log(`Packaging ${target.name}...`)
+    this.log(`Packaging ${target.name} into ${target.artifact}...`)
     const buildPath = Path.join(this.buildDir, target.name)
     const requirementsPath = Path.join(buildPath,this.requirementsFile)
     // Create package directory and package files
@@ -157,7 +158,11 @@ class PkgPyFuncs {
       requirements = _.concat(requirements, this.globalRequirements)
     }
     _.forEach(requirements, (req) => { this.installRequirements(buildPath,req)})
-    zipper.sync.zip(buildPath).compress().save(`${buildPath}.zip`)
+    zipper.sync.zip(buildPath).compress().save(target.artifact)
+    if (this.cleanup) {
+      this.log(`Removing ${buildPath}...`)
+      Fse.removeAsync(buildPath).catch(err => { this.log(err) })
+    }
   }
 
   constructor(serverless, options) {

--- a/index.js
+++ b/index.js
@@ -74,8 +74,9 @@ class PkgPyFuncs {
       return
     }
 
+    let upath = require('upath');
     let cmd = 'pip'
-    let args = ['install','--upgrade','-t', buildPath, '-r', requirementsPath]
+    let args = ['install','--upgrade','-t', upath.normalize(buildPath), '-r', upath.normalize(requirementsPath)]
     if ( this.useDocker === true ){
       cmd = 'docker'
       args = ['exec',this.containerName, 'pip', ...args]

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,10 +60,31 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
       "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
     },
+    "underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
+    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    },
+    "upath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.0.tgz",
+      "integrity": "sha1-tHBrlGHKhHOt+JEz0jVonKF/NlY=",
+      "requires": {
+        "lodash": "3.10.1",
+        "underscore.string": "2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
+      }
     },
     "zip-local": {
       "version": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bluebird": "^3.5.0",
     "fs-extra": "^3.0.0",
     "lodash": "^4.17.4",
+    "upath": "^1.0.0",
     "zip-local": "^0.3.4"
   },
   "repository": {


### PR DESCRIPTION
- When packaging individual functions, actually use the artifact name specified in serverless.yml.
- Clean up build function directory during packaging step if cleanup is true.

These allow for a cleaner package if you are doing serverless package and serverless deploy -p <package_name> as separate steps, and allows for artifacts which don't have to exactly match the deployed function name. 