### PR TITLE
Normalise path for building on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const Fse = require('fs-extra');
 const Path = require('path');
 const ChildProcess = require('child_process');
 const zipper = require('zip-local');
+const upath = require('upath');
 
 BbPromise.promisifyAll(Fse);
 
@@ -73,7 +74,6 @@ class PkgPyFuncs {
       return
     }
 
-    let upath = require('upath');
     let cmd = 'pip'
     let args = ['install','--upgrade','-t', upath.normalize(buildPath), '-r', upath.normalize(requirementsPath)]
     if ( this.useDocker === true ){

--- a/index.js
+++ b/index.js
@@ -73,8 +73,9 @@ class PkgPyFuncs {
       return
     }
 
+    let upath = require('upath');
     let cmd = 'pip'
-    let args = ['install','--upgrade','-t', buildPath, '-r', requirementsPath]
+    let args = ['install','--upgrade','-t', upath.normalize(buildPath), '-r', upath.normalize(requirementsPath)]
     if ( this.useDocker === true ){
       cmd = 'docker'
       args = ['exec',this.containerName, 'pip', ...args]

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,10 +60,31 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
       "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
     },
+    "underscore.string": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+      "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
+    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
       "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+    },
+    "upath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.0.tgz",
+      "integrity": "sha1-tHBrlGHKhHOt+JEz0jVonKF/NlY=",
+      "requires": {
+        "lodash": "3.10.1",
+        "underscore.string": "2.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
+      }
     },
     "zip-local": {
       "version": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bluebird": "^3.5.0",
     "fs-extra": "^3.0.0",
     "lodash": "^4.17.4",
+    "upath": "^1.0.0",
     "zip-local": "^0.3.4"
   },
   "repository": {


### PR DESCRIPTION
It should be possible to build via Linux Docker container on Windows; however, currently this fails due to the windows path format being different.  This change normalises the build and requirements paths so that they are always Linux format, thereby allowing successful pacakge builds using docker on Windows as well as Linux.