### PR TITLE
Isolate global & function includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ custom:
     globalIncludes:
       - ./common_files
     cleanup: true
+    ignorePipVersionCheck: true
 
 functions:
   function1:
@@ -121,15 +122,16 @@ functions:
 
 The plugin configurations are simple:
 
-| Configuration      | Description                                                                                                                                                                                                        | Optional?                                                  |
-|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|
-| buildDir           | Path to a build directory relative to project root, e.g. build                                                                                                                                                     | No                                                         |
-| requirementsFile   | The name of the requirements file used for function-level requirements. All function-level requirements files must use the name specified here.                                                                    | Yes. Defaults to `requirements.txt`                        |
-| globalRequirements | A list of paths to files containing service-level pip requirements.                                                                                                                                                | Yes                                                        |
-| globalIncludes     | A list of paths to folders containing service-level code files (i.e. code common to all functions). Only the folders contents will be packaged, not the folder itself. Paths to files are not currently supported. | Yes                                                        |
-| useDocker          | Boolean indicating whether to package pip dependencies using Docker. Set this to true if your project uses platform-specific compiled libraries like numpy. Requires a [Docker installation](https://www.docker.com/get-docker).                        | Yes. Defaults to `false`                                   |
-| dockerImage        | The Docker image to use to compile functions if `useDocker` is set to `true`. Must be specified as `repository:tag`. If the image doesn't exist on the system, it will be downloaded. The initial download may take some time.                            | Yes. Defaults to `lambci/lambda:build-${provider.runtime}` |
-| containerName      | The desired name for the Docker container.                                                                                                                                                                         | Yes. Defaults to `serverless-package-python-functions`     |
+| Configuration         | Description                                                                                                                                                                                                                      | Optional?                                                  |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|
+| buildDir              | Path to a build directory relative to project root, e.g. build                                                                                                                                                                   | No                                                         |
+| requirementsFile      | The name of the requirements file used for function-level requirements. All function-level requirements files must use the name specified here.                                                                                  | Yes. Defaults to `requirements.txt`                        |
+| globalRequirements    | A list of paths to files containing service-level pip requirements.                                                                                                                                                              | Yes                                                        |
+| globalIncludes        | A list of paths to folders containing service-level code files (i.e. code common to all functions). Only the folders contents will be packaged, not the folder itself. Paths to files are not currently supported.               | Yes                                                        |
+| useDocker             | Boolean indicating whether to package pip dependencies using Docker. Set this to true if your project uses platform-specific compiled libraries like numpy. Requires a [Docker installation](https://www.docker.com/get-docker). | Yes. Defaults to `false`                                   |
+| dockerImage           | The Docker image to use to compile functions if `useDocker` is set to `true`. Must be specified as `repository:tag`. If the image doesn't exist on the system, it will be downloaded. The initial download may take some time.   | Yes. Defaults to `lambci/lambda:build-${provider.runtime}` |
+| containerName         | The desired name for the Docker container.                                                                                                                                                                                       | Yes. Defaults to `serverless-package-python-functions`     |
+| ignorePipVersionCheck | Add `--disable-pip-version-check` flag when installing pip package.                                                                                                                                                              | Yes. Defaults to `false`                                   |
 
 At the function level, you:
 - Specify `name` to give your function a name. The plugin uses the function's name as the name of the zip artifact

--- a/index.js
+++ b/index.js
@@ -144,8 +144,6 @@ class PkgPyFuncs {
   }
 
   makePackage(target){
-    this.log(`Packaging ${target.name}...`)
-
     const buildPath = Path.join(this.buildDir, target.name)
     const requirementsPath = Path.join(buildPath, this.requirementsFile)
     const requirePackages = target.requirePackages;
@@ -154,27 +152,29 @@ class PkgPyFuncs {
     Fse.ensureDirSync(buildPath)
 
     // Write require package to <function folder>/requirements.txt
-    if(requirePackages.length > 0) {
+    if(requirePackages && requirePackages.length > 0) {
       Fse.writeFileSync(buildPath + '/requirements.txt', '')
       requirePackages.forEach(x => {
         Fse.appendFileSync(buildPath + '/requirements.txt', x + '\n')
       });
     }
 
+    let logStr = target.requirePackages ? `with packages: ${target.requirePackages}` : ''
+    this.log(`Packaging ${target.name}... ${logStr}`)
+
     // Copy includes
     let includes = target.includes || []
 
     // Global Includes
-    if(this.globalIncludes.length > 0) {
-      this.log("Add Global Includes")
+    if(this.globalIncludes && this.globalIncludes.length > 0) {
+      this.log("Add Global Includes...")
       _.forEach(this.globalIncludes, (item) => {
-        this.log(`Global include path: ${Path.resolve(buildPath, item)}`)
         Fse.copySync(item, Path.resolve(buildPath, item))
       })
     }
 
     // Functions Include
-    this.log("Add Functions Includes")
+    this.log("Add Functions Includes...")
     _.forEach(includes, (item) => {
       if(Fse.lstatSync(Path.resolve(item)).isDirectory()) {
         Fse.copySync(item, Path.resolve(buildPath)) 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ class PkgPyFuncs {
     this.dockerImage = config.dockerImage || `lambci/lambda:build-${this.serverless.service.provider.runtime}`
     this.containerName = config.containerName || 'serverless-package-python-functions'
     this.dockerServicePath = '/var/task'
+    this.ignorePipVersionCheck = config.ignorePipVersionCheck || false;
   }
 
   clean(){
@@ -57,7 +58,9 @@ class PkgPyFuncs {
       return {
         name: target.name,
         requirePackages: target.requirePackages,
-        includes: target.package.include
+        includes: target.package.include,
+        excludes: target.package.exclude,
+        skip: target.skipPkgPyFuncs
       }
     })
     return info
@@ -85,6 +88,9 @@ class PkgPyFuncs {
     }
 
     args = [...args, upath.normalize(requirementsPath)]
+    if (this.ignorePipVersionCheck) {
+      args.push('--disable-pip-version-check')
+    }
     return this.runProcess(cmd, args)
   }
 
@@ -147,12 +153,15 @@ class PkgPyFuncs {
     const buildPath = Path.join(this.buildDir, target.name)
     const requirementsPath = Path.join(buildPath, this.requirementsFile)
     const requirePackages = target.requirePackages;
+    const excludes = target.excludes || [];
+    const skip = target.skip;
 
     // Create package directory and package files
+    Fse.removeSync(buildPath)
     Fse.ensureDirSync(buildPath)
 
     // Write require package to <function folder>/requirements.txt
-    if(requirePackages && requirePackages.length > 0) {
+    if(!skip && requirePackages && requirePackages.length > 0) {
       Fse.writeFileSync(buildPath + '/requirements.txt', '')
       requirePackages.forEach(x => {
         Fse.appendFileSync(buildPath + '/requirements.txt', x + '\n')
@@ -168,7 +177,14 @@ class PkgPyFuncs {
     // Global Includes
     if(this.globalIncludes && this.globalIncludes.length > 0) {
       this.log("Add Global Includes...")
-      _.forEach(this.globalIncludes, (item) => {
+      _.filter(this.globalIncludes, item => {
+        if (excludes.includes(item)) {
+          this.log(`  Exclude item: ${item}`)
+          return false;
+        } else {
+          return true;
+        }
+      }).forEach(item => {
         Fse.copySync(item, Path.resolve(buildPath, item))
       })
     }
@@ -177,21 +193,23 @@ class PkgPyFuncs {
     this.log("Add Functions Includes...")
     _.forEach(includes, (item) => {
       if(Fse.lstatSync(Path.resolve(item)).isDirectory()) {
-        Fse.copySync(item, Path.resolve(buildPath)) 
+        Fse.copySync(item, Path.resolve(buildPath))
       } else {
-        Fse.copySync(item, Path.resolve(buildPath, item)) 
+        Fse.copySync(item, Path.resolve(buildPath, item))
       }
     })
 
     // Install requirements
-    let requirements = [requirementsPath]
-    if (this.globalRequirements) {
-      requirements = _.concat(requirements, this.globalRequirements)
+    if (!skip) {
+      let requirements = [requirementsPath]
+      if (this.globalRequirements) {
+        requirements = _.concat(requirements, this.globalRequirements)
+      }
+      _.forEach(requirements, (req) => {
+        this.installRequirements(buildPath, req)
+      })
     }
 
-    _.forEach(requirements, (req) => {
-      this.installRequirements(buildPath, req)
-    })
     zipper.sync.zip(buildPath).compress().save(`${buildPath}.zip`)
   }
 


### PR DESCRIPTION
- Isolate global Includes and functions include to ensure folder structure is the same with Local Development and Lamda deployment.
=> globalIncludes can be directory or file path ( Same level with serverless.yml ) so it can keep the structure.
=> All Function level includes will be copied to buildPath/<function-name>/<here> without the folder structure. This is useful in case you are developing multiple functions and the structure like:

```
your-awesome-project/
|── common_files
│   ├── common1.py
│   └── common2.py
├── function1
│   ├── lambda.py
│   └── requirements.txt # with simplejson library
├── lambda2.py
├── lambda3.py
...
├── requirements.txt # with requests library
└── serverless.yml
```
This plugin will package your functions into individual zip files that look like:

```
├── lambda.py # function-level code
├── lambda2.py # function-level code
├── lambda3.py # function-level code
├── requirements.txt
|── common_files # global includes keep the structure
│   ├── common1.py
│   └── common2.py
├── simplejson # function-level dependencies
├── simplejson-3.10.0.dist-info
├── requests # service-level dependencies
└── requests-2.13.0.dist-info
```

- Added function level option **requirePackages** (This will create requiremenFiles on the fly)

Sample yml 

```
awe_some_function:
    name: awe_some_function
    handler: awe_some_function.lambda_handler
    requirePackages:
      - pyjwt
      - bcrypt
    package:
      artifact: awe_some_function.zip
      include:
        - awe_some_function

```
The requirements.txt will be generated and can be used with pip install -r

Thank you!