### PR TITLE
Ignore stderr message

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ class PkgPyFuncs {
     }
 
     if (ret.stderr.length != 0){
-      throw new this.serverless.classes.Error(`[serverless-package-python-functions] ${ret.stderr.toString()}`)
+      this.log(ret.stderr.toString())
     }
 
     const out = ret.stdout.toString()


### PR DESCRIPTION
pip just upgraded to [9.0.2](https://pypi.python.org/pypi/pip) and a new available pip version will produce warning messages. For people that used default docker settings on [lamcli/lambda](https://store.docker.com/community/images/lambci/lambda) (where docker image is still using pip 9.0.1), the change is required for successful deployment.